### PR TITLE
Register `org.firebirdsql.jdbc.FirebirdBlob` type

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,31 +216,33 @@ in the class name containing the static method.
 can pass to the Java method that it can obtain with the method `getNameInfo` from the
 `Context` interface.
 
-#### Supported Java types
+#### Supported Java and Jaybird types
 
-| Java Type            | Compatible Firebird type | Notes |
-| -------------------- | ------------------------ | ----- |
-| byte[]               | BLOB, CHAR, VARCHAR      |       |
-| boolean              | any                      | [1]   |
-| short                | any                      | [1]   |
-| int                  | any                      | [1]   |
-| long                 | any                      | [1]   |
-| float                | any                      | [1]   |
-| double               | any                      | [1]   |
-| java.lang.Boolean    | any                      |       |
-| java.lang.Short      | any                      |       |
-| java.lang.Integer    | any                      |       |
-| java.lang.Long       | any                      |       |
-| java.lang.Float      | any                      |       |
-| java.lang.Double     | any                      |       |
-| java.lang.Object     | any                      | [2]   |
-| java.lang.String     | any                      |       |
-| java.math.BigDecimal | any                      |       |
-| java.sql.Blob        | BLOB                     |       |
-| java.sql.Date        | any                      |       |
-| java.sql.Time        | any                      |       |
-| java.sql.Timestamp   | any                      |       |
-| java.util.Date       | any                      |       |
+| Java or Jaybird Type             | Compatible Firebird type | Notes |
+| --------------------------------- | ------------------------ | ----- |
+| byte[]                            | BLOB, CHAR, VARCHAR      |       |
+| boolean                           | any                      | [1]   |
+| short                             | any                      | [1]   |
+| int                               | any                      | [1]   |
+| long                              | any                      | [1]   |
+| float                             | any                      | [1]   |
+| double                            | any                      | [1]   |
+| java.lang.Boolean                 | any                      |       |
+| java.lang.Short                   | any                      |       |
+| java.lang.Integer                 | any                      |       |
+| java.lang.Long                    | any                      |       |
+| java.lang.Float                   | any                      |       |
+| java.lang.Double                  | any                      |       |
+| java.lang.Object                  | any                      | [2]   |
+| java.lang.String                  | any                      |       |
+| java.math.BigDecimal              | any                      |       |
+| java.sql.Blob                     | BLOB                     |       |
+| java.sql.Date                     | any                      |       |
+| java.sql.Time                     | any                      |       |
+| java.sql.Timestamp                | any                      |       |
+| java.util.Date                    | any                      |       |
+| org.firebirdsql.jdbc.FirebirdBlob | BLOB                     |       |
+
 
 :information_source: [1] A database NULL is converted to `0` (zero) when passed to
 a primitive numeric type and `false` to `boolean`.

--- a/src/fbjava-impl/src/main/java/org/firebirdsql/fbjava/impl/ExternalEngine.java
+++ b/src/fbjava-impl/src/main/java/org/firebirdsql/fbjava/impl/ExternalEngine.java
@@ -479,7 +479,7 @@ final class ExternalEngine implements IExternalEngineIntf
 			}
 		}, new DataTypeReg(byte[].class, "byte[]"));
 
-		// java.sql.Blob
+		// java.sql.Blob and org.firebirdsql.jdbc.FirebirdBlob
 		addDataType(new DataType() {
 			@Override
 			Conversion setupConversion(final IStatus status, final Class<?> javaClass, final IMessageMetadata metadata,
@@ -581,7 +581,7 @@ final class ExternalEngine implements IExternalEngineIntf
 					}
 				};
 			}
-		}, new DataTypeReg(Blob.class, "java.sql.Blob"));
+		}, new DataTypeReg(Blob.class, "java.sql.Blob"), new DataTypeReg(org.firebirdsql.jdbc.FirebirdBlob.class, "org.firebirdsql.jdbc.FirebirdBlob"));
 
 		// short, Short
 		addDataType(new DataType() {

--- a/src/fbjava-impl/src/main/java/org/firebirdsql/fbjava/impl/ExternalEngine.java
+++ b/src/fbjava-impl/src/main/java/org/firebirdsql/fbjava/impl/ExternalEngine.java
@@ -71,6 +71,7 @@ import org.firebirdsql.gds.ISCConstants;
 import org.firebirdsql.gds.impl.GDSHelper;
 import org.firebirdsql.jdbc.FBBlob;
 import org.firebirdsql.jdbc.FBConnection;
+import org.firebirdsql.jdbc.FirebirdBlob;
 
 import com.sun.jna.Pointer;
 
@@ -581,7 +582,7 @@ final class ExternalEngine implements IExternalEngineIntf
 					}
 				};
 			}
-		}, new DataTypeReg(Blob.class, "java.sql.Blob"), new DataTypeReg(org.firebirdsql.jdbc.FirebirdBlob.class, "org.firebirdsql.jdbc.FirebirdBlob"));
+		}, new DataTypeReg(Blob.class, "java.sql.Blob"), new DataTypeReg(FirebirdBlob.class, "org.firebirdsql.jdbc.FirebirdBlob"));
 
 		// short, Short
 		addDataType(new DataType() {


### PR DESCRIPTION
For compatibility with functions that used `org.firebirdsql.jdbc.FirebirdBlob` as parameter